### PR TITLE
chore(bump): avec le bump de knex, l'engine et le charset ne doivent plus être déclarés

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -58,9 +58,7 @@ function syncSchema(result, schema) {
 
 function defineSchemaTable(schema) {
   return function (table) {
-    table.engine('InnoDB');
     table.timestamps();
-    table.charset('utf8');
     (schema.build || _.noop)(table);
   };
 }

--- a/test/unit/sync.js
+++ b/test/unit/sync.js
@@ -104,11 +104,7 @@ describe('Sync', function () {
         expect(knex.schema.createTable).to.have.been.calledTwice;
         expect(knex.schema.createTable).to.have.been.calledWith('a');
         expect(knex.schema.createTable).to.have.been.calledWith('b');
-        expect(table.engine).to.have.been.calledTwice;
-        expect(table.engine).to.have.been.calledWith('InnoDB');
         expect(table.timestamps).to.have.been.calledTwice;
-        expect(table.charset).to.have.been.calledTwice;
-        expect(table.charset).to.have.been.calledWith('utf8');
         expect(schemas[0].build).to.have.been.calledOnce;
         expect(schemas[0].build).to.have.been.calledWith(table);
         expect(schemas[1].build).to.have.been.calledOnce;


### PR DESCRIPTION
```
Knex:warning - Knex only supports engine statement with mysql.
Knex:warning - Knex only supports charset statement with mysql.
```
